### PR TITLE
final fix?

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/fuhsi_logo.png" />
+    <link rel="icon" type="image/svg+xml" href="/fushi.webp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Federal University of Health Sciences, Ila Orangun</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary by Sourcery

Update the HTML page title and favicon path.

Enhancements:
- Set the HTML page title to "Federal University of Health Sciences, Ila Orangun".
- Update the favicon path to "/fushi.webp".